### PR TITLE
Return multiple dreams

### DIFF
--- a/koi_colab_backend.ipynb
+++ b/koi_colab_backend.ipynb
@@ -63,7 +63,8 @@
         "!git clone https://github.com/nousr/koi.git && pip install -e koi\n",
         "!pip install git+https://github.com/huggingface/diffusers.git\n",
         "!pip install ngrok\n",
-        "!pip install flask-ngrok"
+        "!pip install flask-ngrok\n",
+        "!sudo apt install net-tools "
       ],
       "metadata": {
         "id": "cIR9LTKNIT83"
@@ -151,13 +152,13 @@
       "cell_type": "code",
       "source": [
         "import torch\n",
-        "from urllib import request\n",
         "from flask import Flask, Response, request, send_file\n",
         "from PIL import Image\n",
         "from io import BytesIO\n",
         "from torch import autocast\n",
         "from diffusers import StableDiffusionImg2ImgPipeline\n",
         "from click import secho\n",
+        "from zipfile import ZipFile\n",
         "\n",
         "# the following line is specific to remote environments (like google colab)\n",
         "from flask_ngrok import run_with_ngrok\n",
@@ -187,9 +188,10 @@
         "    torch.backends.cudnn.deterministic = True\n",
         "    torch.backends.cudnn.benchmark = True\n",
         "\n",
+        "def get_name(prompt, seed):\n",
+        "  return f'{prompt}-{seed}'\n",
         "\n",
         "# Define one endpoint \"/api/img2img\" for us to communicate with\n",
-        "\n",
         "@app.route(\"/api/img2img\", methods=[\"POST\"])\n",
         "def img2img():\n",
         "    global pipe\n",
@@ -201,26 +203,39 @@
         "    buff = BytesIO(data)\n",
         "    img = Image.open(buff).convert(\"RGB\")\n",
         "\n",
-        "    seed_everything(int(headers[\"seed\"]))\n",
-        "\n",
-        "    with autocast(\"cuda\"):\n",
-        "        return_image = pipe(\n",
-        "            init_image=img,\n",
-        "            prompt=headers[\"prompt\"],\n",
-        "            strength=float(headers[\"sketch_strength\"]),\n",
-        "            guidance_scale=float(headers[\"prompt_strength\"]),\n",
-        "            num_inference_steps=int(headers[\"steps\"]),\n",
-        "        )[\"sample\"][0]\n",
-        "\n",
-        "    return_bytes = BytesIO()\n",
-        "    return_image.save(return_bytes, format=\"JPEG\")\n",
-        "    return_bytes.read()\n",
-        "    return_bytes.seek(0)\n",
-        "\n",
-        "    return send_file(return_bytes, mimetype=\"image/jpeg\")\n",
+        "    seed = int(headers[\"seed\"])\n",
+        "    prompt = headers['prompt']\n",
         "\n",
         "\n",
-        "# This is the part that lets us connect to colab remotely\n",
+        "    print(r.headers)\n",
+        "\n",
+        "    zip_stream = BytesIO()\n",
+        "    with ZipFile(zip_stream, 'w') as zf:\n",
+        "\n",
+        "        for index in range(int(headers['variations'])):\n",
+        "            variation_seed = seed + index\n",
+        "            seed_everything(variation_seed)\n",
+        "        \n",
+        "            with autocast(\"cuda\"):\n",
+        "                return_image = pipe(\n",
+        "                    init_image=img,\n",
+        "                    prompt=prompt,\n",
+        "                    strength=float(headers[\"sketch_strength\"]),\n",
+        "                    guidance_scale=float(headers[\"prompt_strength\"]),\n",
+        "                    num_inference_steps=int(headers[\"steps\"]),\n",
+        "                )[\"sample\"][0]\n",
+        "\n",
+        "\n",
+        "            return_bytes = BytesIO()\n",
+        "            return_image.save(return_bytes, format=\"JPEG\")\n",
+        "\n",
+        "            return_bytes.seek(0)\n",
+        "            zf.writestr(get_name(prompt, variation_seed), return_bytes.read())\n",
+        "\n",
+        "    zip_stream.seek(0)\n",
+        "\n",
+        "    return send_file(zip_stream, mimetype=\"application/zip\")\n",
+        "\n",
         "run_with_ngrok(app)\n",
         "app.run()"
       ],
@@ -261,6 +276,46 @@
       "metadata": {
         "id": "66d9BQVR014n"
       }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Developers Only\n"
+      ],
+      "metadata": {
+        "id": "uZJdQmUMG5iT"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If you need to re-start the flask server in the course of development, killing the cell where it is running won't be enough. Instead you will need to use the commands below to kill the current runtime (which will also kill the running flask server). You can then re-run the flask code again and changes will propagate without needing to reinstall dependencies, log back into huggingface or, download the model again."
+      ],
+      "metadata": {
+        "id": "X_ddlOapI0-o"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!sudo netstat -tulnp | grep :5000"
+      ],
+      "metadata": {
+        "id": "bZXIdJkZH_v_"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!sudo kill 434"
+      ],
+      "metadata": {
+        "id": "Bycf_WAlH_1H"
+      },
+      "execution_count": null,
+      "outputs": []
     }
   ]
 }


### PR DESCRIPTION
Updates the frontend to include a "variations" count, which specified the number for img2img variations that the backend will return. Those variations are then consumed as a zipfile and added as new layers.

The backend is updated to generate multiple variations with different seeds and return these in a zip archive.

#27 
